### PR TITLE
Relaxed strictness when loading weights

### DIFF
--- a/medclip/modeling_medclip.py
+++ b/medclip/modeling_medclip.py
@@ -145,7 +145,7 @@ class MedCLIPModel(nn.Module):
 
         if checkpoint is not None:
             state_dict = torch.load(os.path.join(checkpoint, constants.WEIGHTS_NAME))
-            self.load_state_dict(state_dict)
+            self.load_state_dict(state_dict, strict=False)
             print('load model weight from:', checkpoint)
 
     def from_pretrained(self, input_dir=None):
@@ -182,7 +182,7 @@ class MedCLIPModel(nn.Module):
             print('\n Download pretrained model from:', pretrained_url)
         
         state_dict = torch.load(os.path.join(input_dir, constants.WEIGHTS_NAME))
-        self.load_state_dict(state_dict)
+        self.load_state_dict(state_dict, strict=False)
         print('load model weight from:', input_dir)
 
     def encode_text(self, input_ids=None, attention_mask=None):


### PR DESCRIPTION
The loading of model weights fails due to some transformer version mismatch.  Relaxing the strictness when loading the weights fixes this issue.

https://github.com/RyanWangZf/MedCLIP/issues/37